### PR TITLE
Formatted value for DateTime null value 

### DIFF
--- a/Components/Column.php
+++ b/Components/Column.php
@@ -561,7 +561,7 @@ class Column
                     if (!is_null($rawValue) && is_object($rawValue) && get_class($rawValue) == 'DateTime') {
                         return $rawValue->format($formatParams);
                     } else {
-                        return 'bad argument';
+                        return '';
                     }
                     break;
                 case static::FORMAT_TEXT:
@@ -613,7 +613,7 @@ class Column
                         if (!is_null($rawValue) && is_object($rawValue) && get_class($rawValue) == 'DateTime') {
                             return $rawValue->format($formatParams);
                         } else {
-                            return 'bad argument';
+                            return '';
                         }
                         break;
                     case static::FORMAT_TEXT:


### PR DESCRIPTION
When the value of a date is null, the formatted value to display or export is an empty string.